### PR TITLE
exclude .log and include stipulation of node >= 0.8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ venv/
 static/music
 static/bundle.js
 script/node_modules
+*.log

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ All recent-ish versions of Firefox and Chrome work great with it.
 
 Pots, fyi uses [Browserify](http://browserify.org/) to bundle together
 its client-side dependencies (JQuery, Backbone, Underscore and Handlebars).
-This requires [npm](http://npmjs.org/).
+This requires [npm](http://npmjs.org/) version >= 0.8.0.
 
 ### Quick start
 


### PR DESCRIPTION
In response to this npm error for Browserify:
`npm ERR! Required: ["node >= 0.8.0"]`

I added that caveat to the readme along with the .log change.
